### PR TITLE
Add user property to resolve ErrorException.

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -20,6 +20,11 @@ class Provider extends AbstractProvider
     protected $scopes = [
         'user.info.basic',
     ];
+    
+    /**
+     * @var User
+     */
+    protected $user;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Line 43 of Provider.php accesses an undefined property:

https://github.com/SocialiteProviders/TikTok/blob/b9e27ee78e8bb370691ef0ffc99e4ad712cda469/Provider.php#L43

This PR is to resolve ErrorException: Undefined property: SocialiteProviders\TikTok\Provider::$user