### PR TITLE
Set approvedScopes property on user

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -66,7 +66,8 @@ class Provider extends AbstractProvider
 
         return $this->user->setToken($token)
             ->setExpiresIn(Arr::get($response, 'data.expires_in'))
-            ->setRefreshToken(Arr::get($response, 'data.refresh_token'));
+            ->setRefreshToken(Arr::get($response, 'data.refresh_token'))
+            ->setApprovedScopes(explode($this->scopeSeparator, Arr::get($response, 'data.scope', '')));
     }
 
     /**


### PR DESCRIPTION
Hello,

In my application, I would like to have access to the `data.scope` property that is sent by TikTok at the redirection, but when calling the `user()` method on the provider, the `approvedScope` property is not set so I cannot access them.

My change set this property so we can have access to it when getting the user.