### PR TITLE
get user from official user info endpoint

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -55,10 +55,7 @@ class Provider extends AbstractProvider
         $token = Arr::get($response, 'data.access_token');
 
         $this->user = $this->mapUserToObject(
-            $this->getUserByToken([
-                'access_token' => $token,
-                'open_id'      => Arr::get($response, 'data.open_id'),
-            ])
+            $this->getUserByToken($token)
         );
 
         return $this->user->setToken($token)
@@ -89,20 +86,17 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * Get TikTok user by token.
-     *
-     * @param array $data
-     *
-     * @return mixed
+     * @inheritdoc
      */
-    protected function getUserByToken($data)
+    protected function getUserByToken($token)
     {
-        // Note: The TikTok api does not have an endpoint to get a user by the access
-        // token only. Open id is also required therefore:
-        // $data['access_token'] = $token, $data['open_id'] = $open_id
-
         $response = $this->getHttpClient()->get(
-            'https://open-api.tiktok.com/oauth/userinfo?'.http_build_query($data)
+            'https://open.tiktokapis.com/v2/user/info/?fields=open_id,union_id,display_name,avatar_large_url',
+            [
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $token,
+                ]
+            ]
         );
 
         return json_decode((string) $response->getBody(), true);
@@ -113,13 +107,13 @@ class Provider extends AbstractProvider
      */
     protected function mapUserToObject($user)
     {
-        $user = $user['data'];
+        $user = $user['data']['user'];
 
         return (new User())->setRaw($user)->map([
             'id'       => $user['open_id'],
             'union_id' => $user['union_id'],
             'name'     => $user['display_name'],
-            'avatar'   => $user['avatar_larger'],
+            'avatar'   => $user['avatar_large_url'],
         ]);
     }
 }


### PR DESCRIPTION
The code in master branch gets user details through `open-api.tiktok.com/oauth/userinfo` endpoint which now seems outdated and it is not even mentioned in the current version of official Tiktok API [documentation](https://developers.tiktok.com/doc). And I've faced `Undefined array key "avatar_larger"` issues with it. This endpoint also requires to send `open_id` field besides API access token which is inconsistent from the point of view of code given that the user data is provided in the `getUserByToken` method. 

At the same time there is an official [user details endpoint](https://developers.tiktok.com/doc/tiktok-api-v2-get-user-info) which requires only access token. The fix switches user details acquiring to this endpoint.