### PR TITLE
support null union_id

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -120,7 +120,7 @@ class Provider extends AbstractProvider
 
         return (new User())->setRaw($user)->map([
             'id'       => $user['open_id'],
-            'union_id' => $user['union_id'],
+            'union_id' => $user['union_id'] ?? null,
             'name'     => $user['display_name'],
             'avatar'   => $user['avatar_large_url'],
         ]);


### PR DESCRIPTION
TikTok does not provide the `union_id` field when using "business" scopes and this causes an Exception as this key does not exist in the response. Scope causing this issue:

```
user.info.stats
user.account.type`
user.insights
video.insights
```

And maybe other scopes... This PR takes care of this situation by populating the field with `null` when `union_id` is missing