### PR TITLE
Remove username from fields requested

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -103,7 +103,7 @@ class Provider extends AbstractProvider
                 'Authorization' => 'Bearer '.$token,
             ],
             RequestOptions::QUERY => [
-                'fields' => 'open_id,union_id,display_name,avatar_large_url,username',
+                'fields' => 'open_id,union_id,display_name,avatar_large_url',
             ],
         ]);
 
@@ -119,7 +119,6 @@ class Provider extends AbstractProvider
 
         return (new User())->setRaw($user)->map([
             'id'       => $user['open_id'],
-            'nickname' => $user['username'] ?? null,
             'union_id' => $user['union_id'] ?? null,
             'name'     => $user['display_name'],
             'avatar'   => $user['avatar_large_url'],


### PR DESCRIPTION
As per [tiktok api v2 documentation](https://developers.tiktok.com/doc/tiktok-api-v2-get-user-info#user-object), to request the username field you need the `user.info.profile`scope, not the `user.info.basic` one. Since by default the provider asks just for `user.info.basic`, which i think it's correct.

This PR removes the need for the username field, allowing to keep using `user.info.basic` scope.
